### PR TITLE
Remove the extended constructor in phpDocumentor\Composer\TemplateInstaller

### DIFF
--- a/src/phpDocumentor/Composer/TemplateInstaller.php
+++ b/src/phpDocumentor/Composer/TemplateInstaller.php
@@ -3,20 +3,9 @@
 namespace phpDocumentor\Composer;
 
 use Composer\Package\PackageInterface;
-use Composer\IO\NullIO;
-use Composer\Downloader\DownloadManager;
-use Composer\Repository\WritableRepositoryInterface;
 
 class TemplateInstaller extends \Composer\Installer\LibraryInstaller
 {
-    /**
-     * Override constructor to pass 5th parameter
-     */
-    public function __construct($vendorDir, $binDir, DownloadManager $dm, WritableRepositoryInterface $repository)
-    {
-      parent::__construct($vendorDir, $binDir, $dm, $repository, new NullIO());
-    }
-
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
This change (https://github.com/composer/composer/commit/89e095b4b55c6bca1c3d36d97a937f01c1268e9f#L5L48) altered the signature for the extended constructor. For me the constructor was only introduced to circumvent an previous constructor signature.

I've simply removed the constructor and tested that phpDocumentor2/master is installable through composer with the default responsive template.
