### PR TITLE
Fix template install path for composer installations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "class": "\\phpDocumentor\\Composer\\UnifiedAssetInstaller"
     },
     "require-dev": {
-        "phpunit/phpunit":   "3.7.*@stable",
-        "composer/composer": "1.*@dev"
+        "phpunit/phpunit":   "~3.7",
+        "composer/composer": "~1.0@dev"
     }
 }

--- a/src/phpDocumentor/Composer/UnifiedAssetInstaller.php
+++ b/src/phpDocumentor/Composer/UnifiedAssetInstaller.php
@@ -11,9 +11,10 @@
 
 namespace phpDocumentor\Composer;
 
+use Composer\Installer\LibraryInstaller;
 use Composer\Package\PackageInterface;
 
-class UnifiedAssetInstaller extends \Composer\Installer\LibraryInstaller
+class UnifiedAssetInstaller extends LibraryInstaller
 {
     /**
      * Determines the install path for templates,
@@ -75,9 +76,10 @@ class UnifiedAssetInstaller extends \Composer\Installer\LibraryInstaller
      */
     protected function getTemplateRootPath()
     {
-        return (file_exists($this->vendorDir . '/phpdocumentor/phpdocumentor/composer.json'))
-            ? $this->vendorDir . '/phpdocumentor/phpdocumentor/data/templates'
-            : 'data/templates';
+        return ($this->composer->getPackage()->getName() === 'phpdocumentor/phpdocumentor')
+            ? 'data/templates'
+            : $this->vendorDir . '/phpdocumentor/phpdocumentor/data/templates'
+        ;
     }
 
     /**


### PR DESCRIPTION
This finally resolves the issue of templates being installed to the wrong location when phpDocumentor was used a dependency in another project.

Once merged a new release should be tagged as `1.1` so phpDocumentor's `composer.json` can be updated so that dependencies are resolved correctly.

See also: https://github.com/phpDocumentor/phpDocumentor2/issues/597
