### PR TITLE
Change installation directory for templates

### DIFF
--- a/src/phpDocumentor/Composer/UnifiedAssetInstaller.php
+++ b/src/phpDocumentor/Composer/UnifiedAssetInstaller.php
@@ -78,7 +78,7 @@ class UnifiedAssetInstaller extends LibraryInstaller
     {
         return ($this->composer->getPackage()->getName() === 'phpdocumentor/phpdocumentor')
             ? 'data/templates'
-            : $this->vendorDir . '/phpdocumentor/phpdocumentor/data/templates'
+            : $this->vendorDir . '/phpdocumentor/templates'
         ;
     }
 

--- a/tests/unit/phpDocumentor/Composer/UnifiedAssetInstallerTest.php
+++ b/tests/unit/phpDocumentor/Composer/UnifiedAssetInstallerTest.php
@@ -114,7 +114,7 @@ class UnifiedAssetInstallerTest extends TestCase
             ->will($this->returnValue('phpdocumentor/template-mock'));
 
         $this->assertEquals(
-            $this->vendorDir.'/phpdocumentor/phpdocumentor/data/templates/mock',
+            $this->vendorDir.'/phpdocumentor/templates/mock',
             $library->getInstallPath($package)
         );
     }


### PR DESCRIPTION
This change combined with a change in phpDocumentor/phpDocumentor2 (pull request on its way) should fix https://github.com/phpDocumentor/phpDocumentor2/issues/597 for good.

When phpDocumentor is vendored the templates will now be installed to something like `vendor/phpdocumentor/templates`
There is no change to the installation location when installing dependencies for phpDocumentor itself.
