### PR TITLE
Fix for composer plugin BC break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
     "extra": {
         "class": "\\phpDocumentor\\Composer\\UnifiedAssetInstaller"
     },
+    "require": {
+        "composer-plugin-api": "1.0.0"
+    }
     "require-dev": {
         "phpunit/phpunit":   "~3.7",
         "composer/composer": "~1.0@dev"


### PR DESCRIPTION
New composer plugin support breaks backwards compatibility for plugins of type 'composer-installer'.
Related to https://github.com/phpDocumentor/phpDocumentor2/issues/1035
